### PR TITLE
Allows direct Monolog/Logger di, and a better worker-error message

### DIFF
--- a/config/di.php
+++ b/config/di.php
@@ -9,9 +9,11 @@ use Dragonmantank\Sched\Factory\QueueServiceFactory;
 use Dragonmantank\Sched\Queue\QueueService;
 use Pheanstalk\Pheanstalk;
 use Psr\Log\LoggerInterface;
+use Monolog\Logger;
 
 return [
     'sched-config' => DI\factory(ConfigFactory::class),
+    Logger::class => DI\factory(LoggerInterfaceFactory::class),
     LoggerInterface::class => DI\factory(LoggerInterfaceFactory::class),
     Pheanstalk::class => DI\factory(PheanstalkFactory::class),
     QueueService::class => DI\factory(QueueServiceFactory::class),


### PR DESCRIPTION
The real two reasons I forked this.   

1. I wanted to be able to directly inject a Monolog/Logger instead of just LoggerInterface, so that in the main code it would stop complaining about me using ->withName()
2. The 'worker error' error message, didn't have "what worker" in the error log, so I was getting these but not knowing who/why was causing them.   This'll fix that.